### PR TITLE
Improve error message for missing OpenAI API key

### DIFF
--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -1,7 +1,15 @@
 import { OpenAI } from 'openai';
 
-export const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-  maxRetries: 5,
-  timeout: 60000, // 60 seconds timeout (increased from 30 seconds)
-});
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.warn('OPENAI_API_KEY is not set - AI features will be disabled.');
+}
+
+export const openai = apiKey
+  ? new OpenAI({
+      apiKey,
+      maxRetries: 5,
+      timeout: 60000, // 60 seconds timeout
+    })
+  : null;

--- a/src/pages/api/generate-tailored-resume.js
+++ b/src/pages/api/generate-tailored-resume.js
@@ -7,6 +7,12 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  if (!openai) {
+    return res.status(500).json({
+      error: 'OpenAI API key not configured on server',
+    });
+  }
+
   const { resumeContent, jobDescription, toneStyle = 'professional', keywords = [] } = req.body;
 
   if (!jobDescription) {


### PR DESCRIPTION
## Summary
- warn if `OPENAI_API_KEY` is missing when creating the OpenAI client
- return a clear error from `generate-tailored-resume` API if the key is not set

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c85cc5f3c832caa6f206ff5d7ed3f